### PR TITLE
fix filtering menu (huge mistake omg what did I do)

### DIFF
--- a/src/app/components/Task/slice/index.ts
+++ b/src/app/components/Task/slice/index.ts
@@ -112,11 +112,9 @@ const slice = createSlice({
                         state.preferences.filtering[key];
 
                     for (const setting of settingsToToggle[key]) {
-                        if (setting in settingsToToggle[key]) {
-                            const index = currentSettings.indexOf(setting);
-                            if (index !== -1) currentSettings.splice(index, 1);
-                            else currentSettings.push(setting);
-                        }
+                        const index = currentSettings.indexOf(setting);
+                        if (index !== -1) currentSettings.splice(index, 1);
+                        else currentSettings.push(setting);
                     }
                 }
             }


### PR DESCRIPTION
I destroyed the filtering system (redux dispatcher) by mistaking a "for of" for a "for in", anyway, let's fix that 